### PR TITLE
Add install and update hooks to ensure files route exists.

### DIFF
--- a/modules/openy_gc_log/openy_gc_log.install
+++ b/modules/openy_gc_log/openy_gc_log.install
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Installation file for Open Y Virtual YMCA Log.
+ */
+
+use Drupal\Core\Config\FileStorage;
+
+/**
+ * Implements hook_install().
+ */
+function openy_gc_log_install()
+{
+  _openy_gc_log_check_files_route();
+}
+
+/**
+ * Ensure the route `view.files.page_1` exists and install if it does not.
+ */
+function openy_gc_log_update_8001()
+{
+  _openy_gc_log_check_files_route();
+}
+
+/**
+ * Ensure the route `view.files.page_1` exists and install if it does not.
+ */
+function _openy_gc_log_check_files_route() {
+  $moduleHandler = \Drupal::moduleHandler();
+  $routeProvider = \Drupal::service('router.route_provider');
+  $routes = [];
+  foreach ($routeProvider->getAllRoutes() as $route_name => $route) {
+    $routes[] = $route_name;
+  }
+
+  if ($moduleHandler->moduleExists('file') && !in_array('view.files.page_1', $routes)) {
+    $config_path = drupal_get_path('module', 'file') . '/config/optional';
+    $config_source = new FileStorage($config_path);
+    \Drupal::service('config.installer')->installOptionalConfig($config_source);
+  }
+}


### PR DESCRIPTION
Enabling `openy_gc_log` if the route `view.files.page_1` somehow doesn't exist will result in a whitescreen with:
```
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "view.files.page_1" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 208 of /var/www/docroot/core/lib/Drupal/Core/Routing/RouteProvider.php).
```
 as `openy_gc_log.links.menu.yml` refers to that route. This is similar to [an issue from admin_toolbar](https://www.drupal.org/project/admin_toolbar/issues/2952643).

On install or update, we should ensure this route exists and create it from config if it does not.

# To test
- Start with a site that doesn't have `openy_gc_log`
- Enable Views UI
- If the "Files" view exists, delete it.
- Enable `openy_gc_log`
- Observe the view is recreated
- Observe the Virtual Y > Log Archive link works