### PR TITLE
Backport of the strtolower fix

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -258,7 +258,7 @@ class PersonifyAuthController extends ControllerBase {
 
     if ($data) {
       $results = json_decode($data['Data'], TRUE);
-      if (isset($results['Table'][0]['Access']) && ($results['Table'][0]['Access'] === 'Approved')) {
+      if (isset($results['Table'][0]['Access']) && (strtolower($results['Table'][0]['Access']) === 'approved')) {
         $isActive = TRUE;
       }
     }


### PR DESCRIPTION
Personify server could return APPROVED or Approved statuses. We have to use both.