### PR TITLE
Enabled scheduler for blogpost and vyvideo content types.

### DIFF
--- a/modules/openy_gc_storage/config/install/node.type.gc_video.yml
+++ b/modules/openy_gc_storage/config/install/node.type.gc_video.yml
@@ -10,14 +10,14 @@ third_party_settings:
       - main
     parent: 'main:'
   scheduler:
-    expand_fieldset: when_required
+    expand_fieldset: always
     fields_display_mode: vertical_tab
-    publish_enable: false
-    publish_past_date: error
+    publish_enable: true
+    publish_past_date: publish
     publish_required: false
     publish_revision: false
     publish_touch: false
-    unpublish_enable: false
+    unpublish_enable: true
     unpublish_required: false
     unpublish_revision: false
 name: 'Virtual Y Video'

--- a/modules/openy_gc_storage/config/install/node.type.vy_blog_post.yml
+++ b/modules/openy_gc_storage/config/install/node.type.vy_blog_post.yml
@@ -10,14 +10,14 @@ third_party_settings:
       - main
     parent: 'main:'
   scheduler:
-    expand_fieldset: when_required
+    expand_fieldset: always
     fields_display_mode: vertical_tab
-    publish_enable: false
-    publish_past_date: error
+    publish_enable: true
+    publish_past_date: publish
     publish_required: false
     publish_revision: false
     publish_touch: false
-    unpublish_enable: false
+    unpublish_enable: true
     unpublish_required: false
     unpublish_revision: false
 name: 'Virtual Y blog post'

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -193,3 +193,28 @@ function openy_gc_storage_update_8009() {
     'field.field.eventseries.live_stream.field_ls_media',
   ]);
 }
+
+/**
+ * Enabling scheduler module.
+ */
+function openy_gc_storage_update_8011() {
+  $config_dir = drupal_get_path('module', 'openy_gc_storage') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'node.type.gc_video' => [
+      'dependencies.module',
+      'third_party_settings.scheduler',
+    ],
+    'node.type.vy_blog_post' => [
+      'dependencies.module',
+      'third_party_settings.scheduler',
+    ],
+  ];
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/99

Steps to test:

Navigate to admin/structure/types
Edit the content type(Virtual Y blog post, Virtual Y Video) 
For Virtual Y blog post - admin/structure/types/manage/vy_blog_post
For Virtual Y Video - admin/structure/types/manage/gc_video
Observe the Scheduler vertical tab and check if its enabled. 
Expected results: Scheduler should be enabled for Virtual Y blog post, Virtual Y Video content types.
