### PR TITLE
Handled the case where username are duplicate, If multiple user having same firstname and lastname.

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
@@ -219,6 +219,20 @@ class VirtualYUSALoginForm extends FormBase {
         $name = $result['FirstName'] . ' ' . $result['LastName'];
         $email = $result['Email'];
       }
+      // 4. Case when user name already exist in the system.
+      $users = $this->entityTypeManager
+        ->getStorage('user')
+        ->loadByProperties(['name' => $name]);
+      $user = reset($users);
+      if ($user) {
+        if (in_array($provider_config->get('verification_type'),
+          ['barcode',
+            'membership_id',
+          ])) {
+          $name = 'y-usa+' . $id;
+          $email = $name . '@virtualy.org';
+        }
+      }
       if (!empty($name) && !empty($email)) {
         // Check if user already created.
         $users = $this->entityTypeManager


### PR DESCRIPTION

https://github.com/ymcatwincities/openy_gated_content/issues/163

## Steps to test:


- [ ] Take pull from openy-163 branch.
- [ ] Ensure the Y-USA provide enabled in virtual-y  gc auth settings.(admin/openy/virtual-ymca/gc-auth-settings)
- [ ] Then try login with below mentioned barcodes.( from homepage)
- [ ] Finally observe every user should login into the site.

{
"Barcode": "5252083",
"Email": "pmarebear67@hotmail.com",
"FirstName": "Mary",
"LastName": "Bennett",
}
{
"Barcode": "5577444",
"Email": "Mc58bennett@gmail.com",
"FirstName": "Mary",
"LastName": "Bennett",
}
{
"Barcode": "30044273809",
"Email": "ghill7107@yahoo.com",
"FirstName": "Mary",
"LastName": "Bennett",
}

